### PR TITLE
Simplify Text and Blob

### DIFF
--- a/src/sqlite.zig
+++ b/src/sqlite.zig
@@ -3,16 +3,8 @@ const c = @import("c.zig");
 const errors = @import("errors.zig");
 
 pub const Error = errors.Error;
-pub const Blob = struct { data: []const u8 };
-pub const Text = struct { data: []const u8 };
-
-pub fn blob(data: []const u8) Blob {
-    return .{ .data = data };
-}
-
-pub fn text(data: []const u8) Text {
-    return .{ .data = data };
-}
+pub const Blob = []const u8;
+pub const Text = []const u8;
 
 pub const Database = struct {
     pub const Mode = enum { ReadWrite, ReadOnly };
@@ -260,14 +252,14 @@ pub fn Statement(comptime Params: type, comptime Result: type) type {
         }
 
         fn bindBlob(stmt: Self, idx: c_int, value: Blob) !void {
-            const ptr = value.data.ptr;
-            const len = value.data.len;
+            const ptr = value.ptr;
+            const len = value.len;
             try errors.throw(c.sqlite3_bind_blob64(stmt.ptr, idx, ptr, @intCast(len), c.SQLITE_STATIC));
         }
 
         fn bindText(stmt: Self, idx: c_int, value: Text) !void {
-            const ptr = value.data.ptr;
-            const len = value.data.len;
+            const ptr = value.ptr;
+            const len = value.len;
             try errors.throw(c.sqlite3_bind_text64(stmt.ptr, idx, ptr, @intCast(len), c.SQLITE_STATIC, c.SQLITE_UTF8));
         }
 
@@ -355,7 +347,7 @@ pub fn Statement(comptime Params: type, comptime Result: type) type {
                 std.debug.panic("sqlite3_column_bytes: len < 0", .{});
             }
 
-            return blob(ptr[0..@intCast(len)]);
+            return ptr[0..@intCast(len)];
         }
 
         fn columnText(stmt: Self, n: c_int) Text {
@@ -365,7 +357,7 @@ pub fn Statement(comptime Params: type, comptime Result: type) type {
                 std.debug.panic("sqlite3_column_bytes: len < 0", .{});
             }
 
-            return text(ptr[0..@intCast(len)]);
+            return ptr[0..@intCast(len)];
         }
     };
 }
@@ -388,7 +380,7 @@ const Binding = struct {
 
         pub fn parse(comptime T: type) Type {
             return switch (T) {
-                Blob => .{ .blob = {} },
+                //Blob => .{ .blob = {} },
                 Text => .{ .text = {} },
                 else => switch (@typeInfo(T)) {
                     .Int => |info| switch (info.signedness) {
@@ -411,7 +403,7 @@ const Binding = struct {
 
         pub fn parse(comptime T: type) Kind {
             return switch (T) {
-                Blob => .blob,
+                //Blob => .blob,
                 Text => .text,
                 else => switch (@typeInfo(T)) {
                     .Int => |info| switch (info.signedness) {

--- a/src/sqlite.zig
+++ b/src/sqlite.zig
@@ -380,8 +380,8 @@ const Binding = struct {
 
         pub fn parse(comptime T: type) Type {
             return switch (T) {
-                //Blob => .{ .blob = {} },
-                Text => .{ .text = {} },
+                Blob => .{ .blob = {} },
+                //Text => .{ .text = {} },
                 else => switch (@typeInfo(T)) {
                     .Int => |info| switch (info.signedness) {
                         .signed => if (info.bits <= 32) .{ .int32 = info } else .{ .int64 = info },
@@ -403,8 +403,8 @@ const Binding = struct {
 
         pub fn parse(comptime T: type) Kind {
             return switch (T) {
-                //Blob => .blob,
-                Text => .text,
+                Blob => .blob,
+                //Text => .text,
                 else => switch (@typeInfo(T)) {
                     .Int => |info| switch (info.signedness) {
                         .signed => if (info.bits <= 32) .int32 else .int64,

--- a/src/sqlite.zig
+++ b/src/sqlite.zig
@@ -251,7 +251,7 @@ pub fn Statement(comptime Params: type, comptime Result: type) type {
             try errors.throw(c.sqlite3_bind_int(stmt.ptr, idx, value));
         }
 
-        fn bindInt64(stmt: Self, idx: c_int, value: i32) !void {
+        fn bindInt64(stmt: Self, idx: c_int, value: i64) !void {
             try errors.throw(c.sqlite3_bind_int64(stmt.ptr, idx, value));
         }
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -20,9 +20,9 @@ test "insert" {
         const insert = try db.prepare(User, void, "INSERT INTO users VALUES (:id, :age)");
         defer insert.deinit();
 
-        try insert.exec(.{ .id = sqlite.text("a"), .age = 5 });
-        try insert.exec(.{ .id = sqlite.text("b"), .age = 7 });
-        try insert.exec(.{ .id = sqlite.text("c"), .age = null });
+        try insert.exec(.{ .id = "a", .age = 5 });
+        try insert.exec(.{ .id = "b", .age = 7 });
+        try insert.exec(.{ .id = "c", .age = null });
     }
 
     {
@@ -33,17 +33,17 @@ test "insert" {
         defer select.reset();
 
         if (try select.step()) |user| {
-            try std.testing.expectEqualSlices(u8, "a", user.id.data);
+            try std.testing.expectEqualSlices(u8, "a", user.id);
             try std.testing.expectEqual(@as(?f32, 5), user.age);
         } else try std.testing.expect(false);
 
         if (try select.step()) |user| {
-            try std.testing.expectEqualSlices(u8, "b", user.id.data);
+            try std.testing.expectEqualSlices(u8, "b", user.id);
             try std.testing.expectEqual(@as(?f32, 7), user.age);
         } else try std.testing.expect(false);
 
         if (try select.step()) |user| {
-            try std.testing.expectEqualSlices(u8, "c", user.id.data);
+            try std.testing.expectEqualSlices(u8, "c", user.id);
             try std.testing.expectEqual(@as(?f32, null), user.age);
         } else try std.testing.expect(false);
 
@@ -97,8 +97,8 @@ test "example" {
     );
     defer insert.deinit();
 
-    try insert.exec(.{ .id = sqlite.text("a"), .age = 21 });
-    try insert.exec(.{ .id = sqlite.text("b"), .age = null });
+    try insert.exec(.{ .id = "a", .age = 21 });
+    try insert.exec(.{ .id = "b", .age = null });
 
     const select = try db.prepare(
         struct { min: f32 },
@@ -116,7 +116,7 @@ test "example" {
         if (try select.step()) |user| {
             // user.id: sqlite.Text
             // user.age: ?f32
-            std.log.info("{s} age: {d}", .{ user.id.data, user.age orelse 0 });
+            std.log.info("{s} age: {d}", .{ user.id, user.age orelse 0 });
         }
     }
 
@@ -126,7 +126,7 @@ test "example" {
         defer select.reset();
 
         while (try select.step()) |user| {
-            std.log.info("{s} age: {d}", .{ user.id.data, user.age orelse 0 });
+            std.log.info("{s} age: {d}", .{ user.id, user.age orelse 0 });
         }
     }
 
@@ -136,7 +136,7 @@ test "example" {
         defer select.reset();
 
         while (try select.step()) |user| {
-            std.log.info("{s} age: {d}", .{ user.id.data, user.age orelse 0 });
+            std.log.info("{s} age: {d}", .{ user.id, user.age orelse 0 });
         }
     }
 }


### PR DESCRIPTION
this removes the `sqlite.text()` calls when creating text/blob structs, aswell as the `.data` when reading the data.